### PR TITLE
avoid _rest_request appending '/' to all URIs

### DIFF
--- a/src/redfish/rest/v1.py
+++ b/src/redfish/rest/v1.py
@@ -879,7 +879,7 @@ class HttpClient(RestClientBase):
         :returns: returns a rest request
 
         """
-        if self.default_prefix in path and path[-1] != '/':
+        if self.default_prefix == path and path[-1] != '/':
             path = path + '/'
         else:
             pass


### PR DESCRIPTION
def _rest_request(...) is appending a trailing slash to all URIs:
        if self.default_prefix in path and path[-1] != '/':
            path = path + '/'
        else:
            pass

but my read of the spec says that only needed for the root of the namespace '/redfish/v1/'. Change is to only append when default does not contain a trailing '/'.