### PR TITLE
Add context manager to RestClientBase

### DIFF
--- a/src/redfish/rest/v1.py
+++ b/src/redfish/rest/v1.py
@@ -435,6 +435,14 @@ class RestClientBase(object):
         self._conn = None
         self._conn_count = 0
 
+    def __enter__(self):
+        self.login()
+        return self
+
+    def __exit__(self, exc_type, exc_value, exc_traceback):
+        self.logout()
+        self.__destroy_connection()
+
     def get_username(self):
         """Return used user name"""
         return self.__username


### PR DESCRIPTION
Add enter/exit methods to RestClient base to handle login/logout
when using `with RestClientBase() as d:` syntax