### PR TITLE
Treat gzip data as bytes; unzipped data as string

### DIFF
--- a/src/redfish/rest/v1.py
+++ b/src/redfish/rest/v1.py
@@ -790,9 +790,9 @@ class RestClientBase(object):
 
                 try:
                     if restresp.getheader('content-encoding') == "gzip":
-                        compressedfile = StringIO(restresp.text)
+                        compressedfile = BytesIO(restresp.read)
                         decompressedfile = gzip.GzipFile(fileobj=compressedfile)
-                        restresp.text = decompressedfile.read()
+                        restresp.text = decompressedfile.read().decode("utf-8")
                 except Exception as excp:
                     LOGGER.error('Error occur while decompressing body: %s', \
                                                                         excp)


### PR DESCRIPTION
For issue #22. The original code for handling gzip content type was treating the binary gzipped data as text (string). Updated code to handle the gzip data as bytes and then the unzipped data as a string.

Fixes #22 