### PR TITLE
Correct incorrect use of x-www-form-urlencoded for POST/PATCH/PUT

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -91,12 +91,22 @@ Perform a GET operation
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
  A simple GET operation can be performed to obtain the data present in any valid path.
- An example of rawget operation on the path "/redfish/v1/systems/1 is shown below:
+ An example of rawget operation on the path "/redfish/v1/systems/1" is shown below:
 
 .. code-block:: python
 
 	response = REDFISH_OBJ.get("/redfish/v1/systems/1", None)
 
+Perform a POST operation
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+ A POST operation can be performed to create a resource or perform an action.
+ An example of a POST operation on the path "/redfish/v1/systems/1/Actions/ComputerSystem.Reset" is shown below:
+
+.. code-block:: python
+
+	body = {"ResetType": "GracefulShutdown"}
+	response = REDFISH_OBJ.post("/redfish/v1/systems/1/Actions/ComputerSystem.Reset", body=body)
 
 Logout the created session
 ~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/src/redfish/rest/v1.py
+++ b/src/redfish/rest/v1.py
@@ -735,8 +735,10 @@ class RestClientBase(object):
             if method == 'GET':
                 reqpath += '?' + urlencode(args)
             elif method == 'PUT' or method == 'POST' or method == 'PATCH':
-                headers['Content-Type'] = 'application/x-www-form-urlencoded'
-                body = urlencode(args)
+                LOGGER.warning('For POST, PUT and PATCH methods, the provided "args" parameter "{}" is ignored.'
+                               .format(args))
+                if not body:
+                    LOGGER.warning('Use the "body" parameter to supply the request payload.')
 
         restreq = RestRequest(reqpath, method=method, body=body)
 


### PR DESCRIPTION
The use of `Content-Type: application/x-www-form-urlencoded` is not appropriate for Redfish POST/PATCH/PUT.

Removed the existing code that was doing that and replaced it with a warning.

If a POST, PATCH, or PUT is issued with _both_ an `args=` param and a `body=` param, a warning is issued that indicates the `args=` param is ignored:

> For POST, PUT and PATCH methods, the provided "args" parameter "{'ResetType': 'GracefulShutdown'}" is ignored.

If a POST, PATCH, or PUT is issued with _only_ an `args=` param, a warning is issued that indicates the `args=` param is ignored and that the `body=` param should be used:

> For POST, PUT and PATCH methods, the provided "args" parameter "{'ResetType': 'GracefulShutdown'}" is ignored.
> Use the "body" parameter to supply the request payload.

Fixes #25 
