### PR TITLE
Fix an issue with unit test on config file and py27 and the tempfile module

### DIFF
--- a/tests/ris/test_config.py
+++ b/tests/ris/test_config.py
@@ -1,10 +1,14 @@
 # -*- encoding: utf-8 -*-
 import os
+import shutil
+import sys
 import tempfile
 import textwrap
 import unittest
 
 from redfish.ris.config import AutoConfigParser
+
+py2k = sys.version_info < (3, 0)
 
 
 CONFIG = textwrap.dedent(
@@ -29,23 +33,42 @@ class TestAutoConfigParser(unittest.TestCase):
     def test_init(self):
         acp = AutoConfigParser()
         self.assertEqual(acp._configfile, None)
-        with tempfile.TemporaryDirectory() as tmpdirname:
+        if py2k:
+            tmpdirname = tempfile.mkdtemp()
             cfgfile = "{tmpdir}/config.ini".format(tmpdir=tmpdirname)
             with open(cfgfile, "w+") as config:
                 config.write(CONFIG)
             acp = AutoConfigParser(cfgfile)
             self.assertEqual(acp._configfile, cfgfile)
+            shutil.rmtree(tmpdirname)
+        else:
+            with tempfile.TemporaryDirectory() as tmpdirname:
+                cfgfile = "{tmpdir}/config.ini".format(tmpdir=tmpdirname)
+                with open(cfgfile, "w+") as config:
+                    config.write(CONFIG)
+                acp = AutoConfigParser(cfgfile)
+                self.assertEqual(acp._configfile, cfgfile)
 
     def test_load(self):
-        with tempfile.TemporaryDirectory() as tmpdirname:
+        if py2k:
+            tmpdirname = tempfile.mkdtemp()
             cfgfile = "{tmpdir}/config.ini".format(tmpdir=tmpdirname)
             with open(cfgfile, "w+") as config:
                 config.write(CONFIG)
             acp = AutoConfigParser()
             acp.load(cfgfile)
+            shutil.rmtree(tmpdirname)
+        else:
+            with tempfile.TemporaryDirectory() as tmpdirname:
+                cfgfile = "{tmpdir}/config.ini".format(tmpdir=tmpdirname)
+                with open(cfgfile, "w+") as config:
+                    config.write(CONFIG)
+                acp = AutoConfigParser()
+                acp.load(cfgfile)
 
     def test_save(self):
-        with tempfile.TemporaryDirectory() as tmpdirname:
+        if py2k:
+            tmpdirname = tempfile.mkdtemp()
             cfgfile = "{tmpdir}/config.ini".format(tmpdir=tmpdirname)
             with open(cfgfile, "w+") as config:
                 config.write(CONFIG)
@@ -54,3 +77,14 @@ class TestAutoConfigParser(unittest.TestCase):
             acp.save()
             dump = "{tmpdir}/config2.ini".format(tmpdir=tmpdirname)
             acp.save(dump)
+            shutil.rmtree(tmpdirname)
+        else:
+            with tempfile.TemporaryDirectory() as tmpdirname:
+                cfgfile = "{tmpdir}/config.ini".format(tmpdir=tmpdirname)
+                with open(cfgfile, "w+") as config:
+                    config.write(CONFIG)
+                acp = AutoConfigParser(cfgfile)
+                acp.load()
+                acp.save()
+                dump = "{tmpdir}/config2.ini".format(tmpdir=tmpdirname)
+                acp.save(dump)

--- a/tests/ris/test_config.py
+++ b/tests/ris/test_config.py
@@ -7,7 +7,8 @@ import unittest
 from redfish.ris.config import AutoConfigParser
 
 
-CONFIG = textwrap.dedent("""
+CONFIG = textwrap.dedent(
+    """
     [DEFAULT]
     ServerAliveInterval = 45
     Compression = yes
@@ -20,7 +21,8 @@ CONFIG = textwrap.dedent("""
     [topsecret.server.com]
     Port = 50022
     ForwardX11 = no
-""")
+"""
+)
 
 
 class TestAutoConfigParser(unittest.TestCase):

--- a/tests/ris/test_ris.py
+++ b/tests/ris/test_ris.py
@@ -9,10 +9,7 @@ from redfish.ris.sharedtypes import Dictable
 class TestRisMonolithMemberBase(unittest.TestCase):
     def test_init(self):
         RisMonolithMemberBase()
-        self.assertTrue(issubclass(
-            RisMonolithMemberBase,
-            Dictable
-        ))
+        self.assertTrue(issubclass(RisMonolithMemberBase, Dictable))
 
 
 class TestRisMonolithMember_v1_0_0(unittest.TestCase):
@@ -21,11 +18,7 @@ class TestRisMonolithMember_v1_0_0(unittest.TestCase):
             RisMonolithMember_v1_0_0()
 
         RisMonolithMember_v1_0_0("test")
-        self.assertTrue(issubclass(
-            RisMonolithMember_v1_0_0,
-            RisMonolithMemberBase
-        ))
-        self.assertTrue(issubclass(
-            RisMonolithMember_v1_0_0,
-            Dictable
-        ))
+        self.assertTrue(
+            issubclass(RisMonolithMember_v1_0_0, RisMonolithMemberBase)
+        )
+        self.assertTrue(issubclass(RisMonolithMember_v1_0_0, Dictable))


### PR DESCRIPTION
In python 2.7 to create tmp dir we need to use [`mkdtemp`](https://docs.python.org/2/library/tempfile.html#tempfile.mkdtemp) so fixing the issue and now unit test works well with py27 and py3+

Also applying pep8 on tests too