### PR TITLE
Strip any trailing slashes from base_url

### DIFF
--- a/src/redfish/rest/v1.py
+++ b/src/redfish/rest/v1.py
@@ -434,10 +434,10 @@ class RestClientBase(object):
 
         """
 
-        self.__base_url = base_url
+        self.__base_url = base_url.rstrip('/')
         self.__username = username
         self.__password = password
-        self.__url = urlparse(base_url)
+        self.__url = urlparse(self.__base_url)
         self.__session_key = sessionkey
         self.__authorization_key = None
         self.__session_location = None
@@ -536,7 +536,7 @@ class RestClientBase(object):
         :type url: str
 
         """
-        self.__base_url = url
+        self.__base_url = url.rstrip('/')
 
     def get_session_key(self):
         """Return session key"""


### PR DESCRIPTION
Strip any trailing slashes from `base_url`. For example:

"https://192.168.1.20/" -> "https://192.168.1.20"

This fixes a problem during logout when the base_url is removed from the absolute session URL, resulting in the session URL being transformed from:

`https://192.168.1.20/redfish/v1/SessionService/Sessions/<session_id>`

to:

`redfish/v1/SessionService/Sessions/<session_id>` (note the missing leading slash)

Fixes #57 