### PR TITLE
check if SessionService Link key is present in redfish root data

### DIFF
--- a/src/redfish/rest/v1.py
+++ b/src/redfish/rest/v1.py
@@ -989,12 +989,9 @@ class HttpClient(RestClientBase):
         try:
             self.login_url = self.root.Links.Sessions['@odata.id']
         except KeyError:
-            pass
-
-        try:
-            self.login_url = self.root.SessionService['@odata.id'] + "/Sessions"
-        except KeyError:
-            raise AttributeError("Links and SessionService missing in redfish root object.")
+            # While the "Links/Sessions" property is required, we can fallback
+            # on the URI hardened in 1.6.0 of the specification if not found
+            self.login_url = '/redfish/v1/SessionService/Sessions'
 
     def _rest_request(self, path='', method="GET", args=None, body=None,
                                                                 headers=None):

--- a/src/redfish/rest/v1.py
+++ b/src/redfish/rest/v1.py
@@ -991,7 +991,7 @@ class HttpClient(RestClientBase):
         except KeyError:
             # While the "Links/Sessions" property is required, we can fallback
             # on the URI hardened in 1.6.0 of the specification if not found
-            LOGGER.warning('"Links/Sessions" not found in Service Root.')
+            LOGGER.debug('"Links/Sessions" not found in Service Root.')
             self.login_url = '/redfish/v1/SessionService/Sessions'
 
     def _rest_request(self, path='', method="GET", args=None, body=None,

--- a/src/redfish/rest/v1.py
+++ b/src/redfish/rest/v1.py
@@ -986,7 +986,15 @@ class HttpClient(RestClientBase):
                             cafile=cafile, timeout=timeout, \
                             max_retry=max_retry)
 
-        self.login_url = self.root.Links.Sessions['@odata.id']
+        try:
+            self.login_url = self.root.Links.Sessions['@odata.id']
+        except KeyError:
+            pass
+
+        try:
+            self.login_url = self.root.SessionService['@odata.id'] + "/Sessions"
+        except KeyError:
+            raise AttributeError("Links and SessionService missing in redfish root object.")
 
     def _rest_request(self, path='', method="GET", args=None, body=None,
                                                                 headers=None):

--- a/src/redfish/rest/v1.py
+++ b/src/redfish/rest/v1.py
@@ -991,6 +991,7 @@ class HttpClient(RestClientBase):
         except KeyError:
             # While the "Links/Sessions" property is required, we can fallback
             # on the URI hardened in 1.6.0 of the specification if not found
+            LOGGER.warning('"Links/Sessions" not found in Service Root.')
             self.login_url = '/redfish/v1/SessionService/Sessions'
 
     def _rest_request(self, path='', method="GET", args=None, body=None,


### PR DESCRIPTION
When trying to connect to a Huawei TaiShan server the connect would throw an "KeyError" exception. Huawai didn't implement the "Links" Key. And It shouldn't be assumed the Key to be present.

Here is a example of a Huawei root service:
```
{
    "@odata.context": "/redfish/v1/$metadata#ServiceRoot",
    "@odata.id": "/redfish/v1/",
    "@odata.type": "#ServiceRoot.v1_1_0.ServiceRoot",
    "AccountService": {
        "@odata.id": "/redfish/v1/AccountService"
    },
    "Chassis": {
        "@odata.id": "/redfish/v1/Chassis"
    },
    "EventService": {
        "@odata.id": "/redfish/v1/EventService"
    },
    "Id": "RootService",
    "JsonSchemas": {
        "@odata.id": "/redfish/v1/JSONSchemas"
    },
    "Managers": {
        "@odata.id": "/redfish/v1/Managers"
    },
    "Name": "Root Service",
    "Oem": {
        "Huawei": {
            "AccountLockoutDuration": 300,
            "Copyright": "Huawei Technologies Co., Ltd. 2004-2019. All rights reserved.",
            "DomainName": null,
            "HostName": "",
            "LanguageSet": "en,zh,ja,fr",
            "ProductName": "TaiShan 2280 V2",
            "SecurityBanner": "",
            "SmsUpdateService": null
        }
    },
    "RedfishVersion": "1.0.2",
    "Registries": {
        "@odata.id": "/redfish/v1/Registries"
    },
    "SessionService": {
        "@odata.id": "/redfish/v1/SessionService"
    },
    "Systems": {
        "@odata.id": "/redfish/v1/Systems"
    },
    "Tasks": {
        "@odata.id": "/redfish/v1/TaskService"
    },
    "UUID": "38D36F9E-29C3-4D87-9CF5-5648739E1F95",
    "UpdateService": {
        "@odata.id": "/redfish/v1/UpdateService"
    }
}
```