### PR TITLE
Changed calls to time.clock to use time.perf_counter when Python is older than 3.3

### DIFF
--- a/src/redfish/rest/v1.py
+++ b/src/redfish/rest/v1.py
@@ -811,9 +811,15 @@ class RestClientBase(object):
                                                                 headers=headers)
                     self._conn_count += 1
 
-                    inittime = time.clock()
+                    if sys.version_info < (3, 3):
+                        inittime = time.clock()
+                    else:
+                        inittime = time.perf_counter()
                     resp = self._conn.getresponse()
-                    endtime = time.clock()
+                    if sys.version_info < (3, 3):
+                        endtime = time.clock()
+                    else:
+                        endtime = time.perf_counter()
                     LOGGER.info('Response Time to %s: %s seconds.'% \
                                         (restreq.path, str(endtime-inittime)))
 

--- a/src/redfish/ris/rmc.py
+++ b/src/redfish/ris/rmc.py
@@ -307,9 +307,15 @@ class RmcApp(object):
 
         """
         monolith = self.current_client.monolith
-        inittime = time.clock()
+        if sys.version_info < (3, 3):
+            inittime = time.clock()
+        else:
+            inittime = time.perf_counter()
         monolith.load(path=path, includelogs=includelogs)
-        endtime = time.clock()
+        if sys.version_info < (3, 3):
+            endtime = time.clock()
+        else:
+            endtime = time.perf_counter()
 
         if verbose:
             sys.stdout.write("Monolith build process time: %s\n" % \


### PR DESCRIPTION
Fix #75 