### PR TITLE
Remove urlparse2 dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-jsonpatch
+jsonpatch<=1.24 ; python_version == '3.4'
+jsonpatch ; python_version >= '3.5' or python_version == '2.7'
 jsonpath_rw
 jsonpointer
-urlparse2

--- a/setup.py
+++ b/setup.py
@@ -24,8 +24,14 @@ setup(name='redfish',
       packages=find_packages('src'),
       package_dir={'': 'src'},
       install_requires=[
-          'jsonpatch',
           'jsonpath_rw',
           'jsonpointer',
-          'urlparse2',
-      ])
+      ],
+      extras_require={
+          ':python_version == "3.4"': [
+              'jsonpatch<=1.24'
+          ],
+          ':python_version >= "3.5" or python_version == "2.7"': [
+              'jsonpatch'
+          ]
+      })

--- a/src/redfish/ris/rmc_helper.py
+++ b/src/redfish/ris/rmc_helper.py
@@ -1,5 +1,5 @@
 # Copyright Notice:
-# Copyright 2016-2019 DMTF. All rights reserved.
+# Copyright 2016-2020 DMTF. All rights reserved.
 # License: BSD 3-Clause License. For full text see link: https://github.com/DMTF/python-redfish-library/blob/master/LICENSE.md
 
 # -*- coding: utf-8 -*-

--- a/src/redfish/ris/rmc_helper.py
+++ b/src/redfish/ris/rmc_helper.py
@@ -12,8 +12,9 @@ import json
 import errno
 import logging
 import hashlib
-import urlparse2
 import redfish.rest
+
+from six.moves.urllib.parse import urlparse
 
 from .ris import (RisMonolith)
 from .sharedtypes import (JSONEncoder)
@@ -146,7 +147,7 @@ class RmcClient(object):
 
     def get_cache_dirname(self):
         """The rest client's current base URL converted to path"""
-        parts = urlparse2.urlparse(self.get_base_url())
+        parts = urlparse(self.get_base_url())
         pathstr = '%s/%s' % (parts.netloc, parts.path)
         return pathstr.replace('//', '/')
 

--- a/tests/ris/test_rmc_helper.py
+++ b/tests/ris/test_rmc_helper.py
@@ -1,0 +1,29 @@
+# Copyright Notice:
+# Copyright 2020 DMTF. All rights reserved.
+# License: BSD 3-Clause License. For full text see link:
+#     https://github.com/DMTF/Redfish-Protocol-Validator/blob/master/LICENSE.md
+
+import unittest
+try:
+    from unittest import mock
+except ImportError:
+    import mock
+
+from redfish.ris import rmc_helper
+
+
+class RmcHelper(unittest.TestCase):
+    def setUp(self):
+        super(RmcHelper, self).setUp()
+
+    @mock.patch('redfish.rest.v1.HttpClient')
+    def test_get_cache_dirname(self, mock_http_client):
+        url = 'http://example.com'
+        helper = rmc_helper.RmcClient(url=url, username='oper', password='xyz')
+        mock_http_client.return_value.get_base_url.return_value = url
+        dir_name = helper.get_cache_dirname()
+        self.assertEqual(dir_name, 'example.com/')
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tox.ini
+++ b/tox.ini
@@ -14,6 +14,14 @@ commands =
     --with-timer \
     --with-coverage --cover-erase --cover-package=src
 
+[testenv:py27]
+deps =
+    coverage
+    fixtures
+    mock
+    nose
+    nose-timer
+
 [testenv:pep8]
 basepython = python3.6
 deps = flake8


### PR DESCRIPTION
Made the following updates:

- removed urlparse2 dependency
- added unit test for impacted method
- updated jsonpatch requirements spec (jsonpatch 1.25 dropped Python 3.4 support)

Fixes #78 