### PR TITLE
Add proxy support via environment variables

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,9 @@ var/
 *.manifest
 *.spec
 
+# pyenv
+.python-version
+
 # Installer logs
 pip-log.txt
 pip-delete-this-directory.txt

--- a/README.rst
+++ b/README.rst
@@ -145,6 +145,15 @@ Make sure you logout every session you create as it will remain alive until it t
 
 A logout deletes the current sesssion from the system. The redfish_client object destructor includes a logout statement.
 
+Using proxies
+~~~~~~~~~~~~~
+
+You can use a proxy by specifying the ``HTTP_PROXY`` and ``HTTPS_PROXY`` environment variables.
+
+.. code-block:: shell
+
+    export HTTP_PROXY="http://192.168.1.10:8888"
+    export HTTPS_PROXY="http://192.168.1.10:8888"
 
 Contributing
 ------------


### PR DESCRIPTION
Add proxy support via the HTTP_PROXY and HTTPS_PROXY environment variables, similar to the support in urllib.
