### PR TITLE
tox: add py38 and update testtools prereq for py34

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,py34,py35,py36,py37
+envlist = py27,py34,py35,py36,py37,py38
 
 [testenv]
 usedevelop = True
@@ -21,6 +21,14 @@ deps =
     mock
     nose
     nose-timer
+
+[testenv:py34]
+deps =
+    coverage
+    fixtures
+    nose
+    nose-timer
+    testtools >= 0.9.22, <= 2.3.0
 
 [testenv:pep8]
 basepython = python3.6


### PR DESCRIPTION
- Update tox `testtools` prereq for the py34 environment
- Add py38 to the tox environment list

Fixes #85 