### PR TITLE
Add python 3.8 to travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,10 +6,10 @@ python:
 - '2.7'
 - '3.4'
 - '3.5'
-- 3.5-dev
 - '3.6'
-- 3.6-dev
 - '3.7'
+- '3.8'
+- 3.8-dev
 before_install:
 - pip install -U pip
 - pip install -U setuptools


### PR DESCRIPTION
Added Python 3.8 to the Travis-CI config (.travis.yml). I added both the stable and dev build for 3.8. But I removed the dev builds for 3.5 and 3.6 as those should be quite stable these days.