### PR TITLE
Fix logout failure while base URL scheme is HTTP

### DIFF
--- a/src/redfish/rest/v1.py
+++ b/src/redfish/rest/v1.py
@@ -979,7 +979,7 @@ class RestClientBase(object):
         """ Logout of session. YOU MUST CALL THIS WHEN YOU ARE DONE TO FREE"""
         """ UP SESSIONS"""
         if self.__session_key:
-            session_loc = self.__session_location.replace(self.__base_url, '')
+            session_loc = urlunparse(('', '') + urlparse(self.__session_location)[2:])
 
             resp = self.delete(session_loc)
             if resp.status not in [200, 202, 204]:

--- a/src/redfish/rest/v1.py
+++ b/src/redfish/rest/v1.py
@@ -979,7 +979,7 @@ class RestClientBase(object):
         """ Logout of session. YOU MUST CALL THIS WHEN YOU ARE DONE TO FREE"""
         """ UP SESSIONS"""
         if self.__session_key:
-            session_loc = urlunparse(('', '') + urlparse(self.__session_location)[2:])
+            session_loc = urlparse(self.__session_location).path
 
             resp = self.delete(session_loc)
             if resp.status not in [200, 202, 204]:


### PR DESCRIPTION
When base URL scheme is HTTP, logout will fail as below:

```
>>> from redfish import redfish_client
>>> with redfish_client('https://10.30.170.53','',''): pass
... 
>>> with redfish_client('http://10.30.170.53','',''): pass
... 
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/tmp/python-redfish-library/src/redfish/rest/v1.py", line 532, in __exit__
    self.logout()
  File "/tmp/python-redfish-library/src/redfish/rest/v1.py", line 987, in logout
    "return code: %d" % (session_loc, resp.status))
redfish.rest.v1.BadRequestError: Invalid session resource: https://10.30.170.53/redfish/v1/SessionService/Sessions/%5bnone%5d000000005f22dae6170a3d71/, return code: 405
```

The root cause is that the scheme of `self.__base_url` is still HTTP rather than HTTPS the Redfish API uses.

Although user should provide HTTPS URL for Redfish API as README described, `redfish_client` (and internal `RestClientBase`) process HTTP redirection well, I suggest make `logout` robust in order to handle HTTP URL case as well.