### PR TITLE
Make HTTP headers Accept and OData-Version configurable for user

### DIFF
--- a/src/redfish/rest/v1.py
+++ b/src/redfish/rest/v1.py
@@ -746,7 +746,9 @@ class RestClientBase(object):
         elif self.__authorization_key:
             headers['Authorization'] = self.__authorization_key
 
-        headers['Accept'] = '*/*'
+        if 'Accept' not in headers:
+            headers['Accept'] = '*/*'
+
         headers['Connection'] = 'Keep-Alive'
 
         return headers
@@ -1069,7 +1071,8 @@ class HttpClient(RestClientBase):
 
         """
         headers = super(HttpClient, self)._get_req_headers(headers)
-        headers['OData-Version'] = '4.0'
+        if 'OData-Version' not in headers:
+            headers['OData-Version'] = '4.0'
 
         return headers
 

--- a/src/redfish/rest/v1.py
+++ b/src/redfish/rest/v1.py
@@ -746,7 +746,8 @@ class RestClientBase(object):
         elif self.__authorization_key:
             headers['Authorization'] = self.__authorization_key
 
-        if 'Accept' not in headers:
+        headers_keys = set(k.lower() for k in headers)
+        if 'accept' not in headers_keys:
             headers['Accept'] = '*/*'
 
         headers['Connection'] = 'Keep-Alive'
@@ -1071,7 +1072,8 @@ class HttpClient(RestClientBase):
 
         """
         headers = super(HttpClient, self)._get_req_headers(headers)
-        if 'OData-Version' not in headers:
+        headers_keys = set(k.lower() for k in headers)
+        if 'odata-version' not in headers_keys:
             headers['OData-Version'] = '4.0'
 
         return headers


### PR DESCRIPTION
As in subject, these headers 

Test script

```
import redfish

REDFISH_OBJ = redfish.redfish_client(
        base_url='https://10.172.201.217',
        username='admin', password='admin',
        default_prefix='/redfish/v1')

REDFISH_OBJ.login()
iheaders = {'Accept': 'application/xml'}
response = REDFISH_OBJ.get('/redfish/v1/Managers', headers=iheaders)
print (f"Request with Accept header set to application/xml: status {response.status}")

response = REDFISH_OBJ.get('/redfish/v1/Managers')
print (f"Request without defined headers: status {response.status}")

iheaders = {'OData-Version': '5.0'}
response = REDFISH_OBJ.get('/redfish/v1/Managers', headers=iheaders)
print (f"Request with OData-Version header set to 5.0: status {response.status}")

iheaders = {'Accept': 'application/json'}
response = REDFISH_OBJ.get('/redfish/v1/Managers', headers=iheaders)
print (f"Request with Accept header set to application/json: status {response.status}")

REDFISH_OBJ.logout()
```