### PR TITLE
Add py39 to tox and travis configs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,6 @@ python:
 - '3.7'
 - '3.8'
 - '3.9'
-- 3.8-dev
 before_install:
 - pip install -U pip
 - pip install -U setuptools

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ python:
 - '3.6'
 - '3.7'
 - '3.8'
+- '3.9'
 - 3.8-dev
 before_install:
 - pip install -U pip

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,py34,py35,py36,py37,py38
+envlist = py27,py34,py35,py36,py37,py38,py39
 
 [testenv]
 usedevelop = True


### PR DESCRIPTION
Also, remove 3.8-dev from .travis.yml since the regular released 3.8 is already specified.

Fixes #103