### PR TITLE
Converting the library to use requests

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,5 @@ jsonpatch ; python_version >= '3.5'
 jsonpath_rw
 jsonpointer
 urllib3
+requests
 requests-toolbelt

--- a/setup.py
+++ b/setup.py
@@ -31,6 +31,7 @@ setup(name='redfish',
       install_requires=[
           'jsonpath_rw',
           'jsonpointer',
+          "requests",
           'requests_toolbelt',
       ],
       extras_require={

--- a/src/redfish/rest/v1.py
+++ b/src/redfish/rest/v1.py
@@ -155,13 +155,17 @@ class RestResponse(object):
         :type http_response: requests.Response
 
         """
-        self._read = http_response.text
-        self._status = http_response.status_code
+        self._read = None
+        self._status = None
         self._session_key = None
         self._session_location = None
         self._task_location = None
         self._rest_request = rest_request
         self._http_response = http_response
+
+        if http_response is not None:
+            self._read = http_response.text
+            self._status = http_response.status_code
 
     @property
     def read(self):

--- a/src/redfish/rest/v1.py
+++ b/src/redfish/rest/v1.py
@@ -462,11 +462,6 @@ class RestClientBase(object):
 
     def __exit__(self, exc_type, exc_value, exc_traceback):
         self.logout()
-        self._session.close()
-
-    def __del__(self):
-        self.logout()
-        self._session.close()
 
     def get_username(self):
         """Return used user name"""
@@ -941,6 +936,7 @@ class RestClientBase(object):
             self.__session_key = None
             self.__session_location = None
             self.__authorization_key = None
+        self._session.close()
 
 class HttpClient(RestClientBase):
     """A client for Rest"""


### PR DESCRIPTION
Looking to simplify the library by leveraging requests instead of http.client since requests has functionality we're currently duplicating in this library.

Need more eyes on this to see how this integrates with existing tools.

There are more things I'd like to remove since some of the internal helper classes seem to duplicate data in several places, but the current changes address the bulk of the heavy lifting we've done prior that are handled internally with requests.