### PR TITLE
Added methods for specifying proxies directly

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -72,6 +72,7 @@ There are several optional parameters:
 * ``cafile``: The file path to the CA certificate that issued the Redfish service's certificate.  The default value is ``None``.
 * ``timeout``: The number of seconds to wait for a response before closing the connection.  The default value is ``None``.
 * ``max_retry``: The number of retries to perform an operation before giving up.  The default value is ``10``.
+* ``proxies``: A dictionary containing protocol to proxy URL mappings.  The default value is ``None``.  See `Using proxies`_.
 
 To crete a Redfish object, call the ``redfish_client`` method:
 
@@ -147,12 +148,32 @@ The ``logout`` operation deletes the current sesssion from the service.  The ``r
 Using proxies
 ~~~~~~~~~~~~~
 
+There are two methods for using proxies.
+
+Environment variables
+^^^^^^^^^^^^^^^^^^^^^
+
 You can use a proxy by specifying the ``HTTP_PROXY`` and ``HTTPS_PROXY`` environment variables.  Hosts to be excluded from the proxy can be specified using the NO_PROXY environment variable.
 
 .. code-block:: shell
 
     export HTTP_PROXY="http://192.168.1.10:8888"
     export HTTPS_PROXY="http://192.168.1.10:8888"
+
+Directly provided
+^^^^^^^^^^^^^^^^^
+
+You can use a proxy by building a dictionary containing the proxy information and providing it to the ``proxies`` argument when creating the ``redfish_client`` object.
+The key-value pairs of the dictionary contain the protocol and the proxy URL for the protocol.
+
+.. code-block:: python
+
+    proxies = {
+        'http': 'http://192.168.1.10:8888',
+        'https': 'http://192.168.1.10:8888',
+    }
+    REDFISH_OBJ = redfish.redfish_client(base_url=login_host, username=login_account, \
+                          password=login_password, proxies=proxies)
 
 Contributing
 ------------

--- a/src/redfish/rest/v1.py
+++ b/src/redfish/rest/v1.py
@@ -440,7 +440,7 @@ class RestClientBase(object):
     def __init__(self, base_url, username=None, password=None,
                                 default_prefix='/redfish/v1/', sessionkey=None,
                                 capath=None, cafile=None, timeout=None,
-                                max_retry=None):
+                                max_retry=None, proxies=None):
         """Initialization of the base class RestClientBase
 
         :param base_url: The URL of the remote system
@@ -461,6 +461,8 @@ class RestClientBase(object):
         :type timeout: int
         :param max_retry: Number of times a request will retry after a timeout
         :type max_retry: int
+        :param proxies: Dictionary containing protocol to proxy URL mappings
+        :type proxies: dict
 
         """
 
@@ -476,6 +478,7 @@ class RestClientBase(object):
             self._session = requests.Session()
         self._timeout = timeout
         self._max_retry = max_retry if max_retry is not None else 10
+        self._proxies = proxies
         self.login_url = None
         self.default_prefix = default_prefix
         self.capath = capath
@@ -848,7 +851,7 @@ class RestClientBase(object):
                     verify = self.cafile
                 resp = self._session.request(method.upper(), "{}{}".format(self.__base_url, reqpath), data=body,
                                              headers=headers, timeout=self._timeout, allow_redirects=allow_redirects,
-                                             verify=verify)
+                                             verify=verify, proxies=self._proxies)
 
                 if sys.version_info < (3, 3):
                     endtime = time.clock()
@@ -970,7 +973,7 @@ class HttpClient(RestClientBase):
                                 default_prefix='/redfish/v1/',
                                 sessionkey=None, capath=None,
                                 cafile=None, timeout=None,
-                                max_retry=None):
+                                max_retry=None, proxies=None):
         """Initialize HttpClient
 
         :param base_url: The url of the remote system
@@ -991,13 +994,15 @@ class HttpClient(RestClientBase):
         :type timeout: int
         :param max_retry: Number of times a request will retry after a timeout
         :type max_retry: int
+        :param proxies: Dictionary containing protocol to proxy URL mappings
+        :type proxies: dict
 
         """
         super(HttpClient, self).__init__(base_url, username=username,
                             password=password, default_prefix=default_prefix,
                             sessionkey=sessionkey, capath=capath,
                             cafile=cafile, timeout=timeout,
-                            max_retry=max_retry)
+                            max_retry=max_retry, proxies=proxies)
 
         try:
             self.login_url = self.root.Links.Sessions['@odata.id']
@@ -1050,7 +1055,7 @@ def redfish_client(base_url=None, username=None, password=None,
                                 default_prefix='/redfish/v1/',
                                 sessionkey=None, capath=None,
                                 cafile=None, timeout=None,
-                                max_retry=None):
+                                max_retry=None, proxies=None):
     """Create and return appropriate REDFISH client instance."""
     """ Instantiates appropriate Redfish object based on existing"""
     """ configuration. Use this to retrieve a pre-configured Redfish object
@@ -1073,6 +1078,8 @@ def redfish_client(base_url=None, username=None, password=None,
     :type timeout: int
     :param max_retry: Number of times a request will retry after a timeout
     :type max_retry: int
+    :param proxies: Dictionary containing protocol to proxy URL mappings
+    :type proxies: dict
     :returns: a client object.
 
     """
@@ -1082,4 +1089,4 @@ def redfish_client(base_url=None, username=None, password=None,
     return HttpClient(base_url=base_url, username=username, password=password,
                         default_prefix=default_prefix, sessionkey=sessionkey,
                         capath=capath, cafile=cafile, timeout=timeout,
-                        max_retry=max_retry)
+                        max_retry=max_retry, proxies=proxies)

--- a/src/redfish/ris/rmc.py
+++ b/src/redfish/ris/rmc.py
@@ -252,7 +252,7 @@ class RmcApp(object):
     current_client = property(get_current_client, None)
 
     def login(self, username=None, password=None, base_url=None, verbose=False,
-                                path=None, skipbuild=False, includelogs=False):
+                                path=None, skipbuild=False, includelogs=False, proxies=None):
         """Main worker function for login command
 
         :param username: user name required to login to server.
@@ -269,6 +269,8 @@ class RmcApp(object):
         :type skipbuild: boolean.
         :param includelogs: flag to determine id logs should be downloaded.
         :type includelogs: boolean.
+        :param proxies: Dictionary containing protocol to proxy URL mappings
+        :type proxies: dict
 
         """
         if not self.check_current_rmc_client(url=base_url):
@@ -279,11 +281,12 @@ class RmcApp(object):
         existing_client = self.get_rmc_client(url=base_url)
         if existing_client:
             self.update_rmc_client(url=base_url, username=username,
-                                                            password=password)
+                                   password=password)
         else:
             try:
                 self.add_rmc_client(RmcClient(username=username,
-                                              password=password, url=base_url))
+                                              password=password, url=base_url,
+                                              proxies=proxies))
             except Exception as excp:
                 raise excp
 

--- a/src/redfish/ris/rmc_helper.py
+++ b/src/redfish/ris/rmc_helper.py
@@ -82,7 +82,8 @@ class InvalidPathError(Exception):
 
 class RmcClient(object):
     """RMC client base class"""
-    def __init__(self, url=None, username=None, password=None, sessionkey=None):
+    def __init__(self, url=None, username=None, password=None, sessionkey=None,
+                 proxies=None):
         """Initialized RmcClient
         :param url: redfish host name or IP address.
         :type url: str.
@@ -92,10 +93,13 @@ class RmcClient(object):
         :type password: str.
         :param sessionkey: session key credential for current login
         :type sessionkey: str
+        :param proxies: Dictionary containing protocol to proxy URL mappings
+        :type proxies: dict
 
         """
-        self._rest_client = redfish.rest.v1.redfish_client(base_url=url,
-                   username=username, password=password, sessionkey=sessionkey)
+        self._rest_client = redfish.rest.v1.redfish_client(
+            base_url=url, username=username, password=password,
+            sessionkey=sessionkey, proxies=proxies)
 
         self._get_cache = dict()
         self._monolith = RisMonolith(self)


### PR DESCRIPTION
Leverages `proxies` parameter in the requests module so that environment variables are not required to use proxies.

Signed-off-by: Mike Raineri <michael.raineri@dell.com>