### PR TITLE
ServerDownOrUnreachableError swallows original exception message, mak…

### DIFF
--- a/src/redfish/rest/v1.py
+++ b/src/redfish/rest/v1.py
@@ -52,7 +52,9 @@ class SessionCreationError(Exception):
 
 class ServerDownOrUnreachableError(Exception):
     """Raised when server is unreachable."""
-    pass
+    def __init__(self,message,*,response=None):
+        super().__init__(message)
+        self.response = response
 
 class DecompressResponseError(Exception):
     """Raised when decompressing response failed."""
@@ -590,7 +592,7 @@ class RestClientBase(object):
 
         if resp.status != 200:
             raise ServerDownOrUnreachableError("Server not reachable, " \
-                                               "return code: %d" % resp.status)
+                                               "return code: %d" % resp.status,response=resp)
 
         content = resp.text
 


### PR DESCRIPTION
…ing it confusing to determine

whether server is down or there is an incorrect authorization. This change copies the original response into the exception.

This is useful for client libaries that cache session keys to known whether the key has expired or there is some other issue (e.g. server is offline).

Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.

Everyone is permitted to copy and distribute verbatim copies of this license document, but changing it is not allowed.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: Gerard Weatherby <gweatherby@uchc.edu>