### PR TITLE
Fix syntax warnings with Python 3.12

### DIFF
--- a/src/redfish/discovery/discovery.py
+++ b/src/redfish/discovery/discovery.py
@@ -99,7 +99,7 @@ def discover_ssdp(port=1900, ttl=2, response_time=3, iface=None, protocol="ipv4"
     # On the same socket, wait for responses
     discovered_services = {}
     pattern = re.compile(
-        "^uuid:([a-f0-9\-]*)::urn:dmtf-org:service:redfish-rest:1(:\d+)?$") # noqa
+        r"^uuid:([a-f0-9\-]*)::urn:dmtf-org:service:redfish-rest:1(:\d+)?$") # noqa
     while True:
         try:
             response = http.client.HTTPResponse(FakeSocket(sock.recv(1024)))

--- a/src/redfish/messages/messages.py
+++ b/src/redfish/messages/messages.py
@@ -104,7 +104,7 @@ def search_message(response, message_registry_group, message_registry_id):
     else:
         messages_detail = get_messages_detail(response)
 
-    message_registry_id_search = "^" + message_registry_group + "\.[0-9]+\.[0-9]+\." + message_registry_id +"$"
+    message_registry_id_search = "^" + message_registry_group + r"\.[0-9]+\.[0-9]+\." + message_registry_id +"$"
 
     for messages_item in messages_detail["@Message.ExtendedInfo"]:
         if "MessageId" in messages_item:

--- a/src/redfish/rest/v1.py
+++ b/src/redfish/rest/v1.py
@@ -886,7 +886,7 @@ class RestClientBase(object):
                         if restreq.body[0] == '{':
                             # Mask password properties
                             # NOTE: If the password itself contains a double quote, it will not redact the entire password
-                            logbody = re.sub('"Password"\s*:\s*".*?"', '"Password": "<REDACTED>"', restreq.body)
+                            logbody = re.sub(r'"Password"\s*:\s*".*?"', '"Password": "<REDACTED>"', restreq.body)
                         else:
                             raise ValueError('Body of message is binary')
                     LOGGER.debug('HTTP REQUEST (%s) for %s:\nHeaders:\n%s\nBody: %s\n'% \


### PR DESCRIPTION
Python 3.12 introduced a SyntaxWarning for invalid escape sequences in string literals. Use raw string literals where strings with backslash characters are required.