### PR TITLE
Issue #163: Optional Connection upon Client Instantiation

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -91,6 +91,7 @@ There are several optional parameters:
 * ``timeout``: The number of seconds to wait for a response before closing the connection.  The default value is ``None``.
 * ``max_retry``: The number of retries to perform an operation before giving up.  The default value is ``10``.
 * ``proxies``: A dictionary containing protocol to proxy URL mappings.  The default value is ``None``.  See `Using proxies`_.
+* ``check_connectivity``: A boolean value to determine whether the client immediately attempts a connection to the base_url. The default is ``True``.
 
 To create a Redfish object, call the ``redfish_client`` method:
 

--- a/src/redfish/rest/v1.py
+++ b/src/redfish/rest/v1.py
@@ -477,6 +477,9 @@ class RestClientBase(object):
         :type max_retry: int
         :param proxies: Dictionary containing protocol to proxy URL mappings
         :type proxies: dict
+        :param check_connectivity: A boolean to determine whether the client immediately checks for
+        connectivity to the base_url or not.
+        :type check_connectivity: bool
 
         """
 
@@ -1069,6 +1072,9 @@ class HttpClient(RestClientBase):
         :type max_retry: int
         :param proxies: Dictionary containing protocol to proxy URL mappings
         :type proxies: dict
+        :param check_connectivity: A boolean to determine whether the client immediately checks for
+        connectivity to the base_url or not.
+        :type check_connectivity: bool
 
         """
         super(HttpClient, self).__init__(base_url, username=username,
@@ -1158,6 +1164,9 @@ def redfish_client(base_url=None, username=None, password=None,
     :type max_retry: int
     :param proxies: Dictionary containing protocol to proxy URL mappings
     :type proxies: dict
+    :param check_connectivity: A boolean to determine whether the client immediately checks for
+    connectivity to the base_url or not.
+    :type check_connectivity: bool
     :returns: a client object.
 
     """

--- a/src/redfish/rest/v1.py
+++ b/src/redfish/rest/v1.py
@@ -454,7 +454,7 @@ class RestClientBase(object):
     def __init__(self, base_url, username=None, password=None,
                                 default_prefix='/redfish/v1/', sessionkey=None,
                                 capath=None, cafile=None, timeout=None,
-                                max_retry=None, proxies=None):
+                                max_retry=None, proxies=None, check_connectivity=True):
         """Initialization of the base class RestClientBase
 
         :param base_url: The URL of the remote system
@@ -497,7 +497,9 @@ class RestClientBase(object):
         self.default_prefix = default_prefix
         self.capath = capath
         self.cafile = cafile
-        self.get_root_object()
+
+        if check_connectivity:
+            self.get_root_object()
 
     def __enter__(self):
         self.login()
@@ -999,7 +1001,7 @@ class RestClientBase(object):
             message_item = search_message(resp, "Base", "PasswordChangeRequired")
             if not message_item is None:
                 raise RedfishPasswordChangeRequiredError("Password Change Required\n", message_item["MessageArgs"][0])
-            
+
             if not self.__session_key and resp.status not in [200, 201, 202, 204]:
                 if resp.status == 401:
                     # Invalid credentials supplied
@@ -1042,7 +1044,7 @@ class HttpClient(RestClientBase):
                                 default_prefix='/redfish/v1/',
                                 sessionkey=None, capath=None,
                                 cafile=None, timeout=None,
-                                max_retry=None, proxies=None):
+                                max_retry=None, proxies=None, check_connectivity=True):
         """Initialize HttpClient
 
         :param base_url: The url of the remote system
@@ -1071,11 +1073,12 @@ class HttpClient(RestClientBase):
                             password=password, default_prefix=default_prefix,
                             sessionkey=sessionkey, capath=capath,
                             cafile=cafile, timeout=timeout,
-                            max_retry=max_retry, proxies=proxies)
+                            max_retry=max_retry, proxies=proxies,
+                            check_connectivity=check_connectivity)
 
         try:
             self.login_url = self.root.Links.Sessions['@odata.id']
-        except KeyError:
+        except (KeyError, AttributeError):
             # While the "Links/Sessions" property is required, we can fallback
             # on the URI hardened in 1.6.0 of the specification if not found
             LOGGER.debug('"Links/Sessions" not found in Service Root.')
@@ -1128,7 +1131,7 @@ def redfish_client(base_url=None, username=None, password=None,
                                 default_prefix='/redfish/v1/',
                                 sessionkey=None, capath=None,
                                 cafile=None, timeout=None,
-                                max_retry=None, proxies=None):
+                                max_retry=None, proxies=None, check_connectivity=True):
     """Create and return appropriate REDFISH client instance."""
     """ Instantiates appropriate Redfish object based on existing"""
     """ configuration. Use this to retrieve a pre-configured Redfish object
@@ -1162,4 +1165,4 @@ def redfish_client(base_url=None, username=None, password=None,
     return HttpClient(base_url=base_url, username=username, password=password,
                         default_prefix=default_prefix, sessionkey=sessionkey,
                         capath=capath, cafile=cafile, timeout=timeout,
-                        max_retry=max_retry, proxies=proxies)
+                        max_retry=max_retry, proxies=proxies, check_connectivity=check_connectivity)

--- a/src/redfish/rest/v1.py
+++ b/src/redfish/rest/v1.py
@@ -967,6 +967,8 @@ class RestClientBase(object):
         :type auth: object/instance of class AuthMethod
 
         """
+        if getattr(self, "root_resp", None) is None:
+            self.get_root_object()
 
         self.__username = username if username else self.__username
         self.__password = password if password else self.__password

--- a/tests/rest/test_v1.py
+++ b/tests/rest/test_v1.py
@@ -6,38 +6,45 @@
 # -*- encoding: utf-8 -*-
 import unittest
 
-from redfish.rest.v1 import HttpClient
-from redfish.rest.v1 import RetriesExhaustedError
-from redfish.rest.v1 import redfish_client
+from redfish.rest.v1 import HttpClient, RetriesExhaustedError, redfish_client
 
 
 class TestRedFishClient(unittest.TestCase):
+    def setUp(self):
+        self.base_url = "http://foo.bar"
+        self.username = "rstallman"
+        self.password = "123456"
+        self.default_prefix = "/custom/redfish/v1/"
+        self.sessionkey = "fg687glgkf56vlgkf"
+        self.capath = "/path/to/the/dir"
+        self.cafile = "filename.test"
+        self.timeout = 666
+        self.max_retry = 42
+
     def test_redfish_client(self):
-        base_url = "http://foo.bar"
-        username = "rstallman"
-        password = "123456"
-        default_prefix = "/custom/redfish/v1/"
-        sessionkey = "fg687glgkf56vlgkf"
-        capath = "/path/to/the/dir"
-        cafile = "filename.test"
-        timeout = 666
-        max_retry = 42
         # NOTE(hberaud) the client try to connect when we initialize the
         # http client object so we need to catch the retries exception first.
         # In a second time we need to mock the six.http_client to simulate
         # server responses and do some other tests
         with self.assertRaises(RetriesExhaustedError):
-            client = redfish_client(base_url=base_url)
+            client = redfish_client(base_url=self.base_url)
             # Check the object type
             self.assertTrue(isinstance(client, HttpClient))
             # Check the object attributes values.
             # Here we check if the client object is properly initialized
-            self.assertEqual(client.base_url, base_url)
-            self.assertEqual(client.username, username)
-            self.assertEqual(client.password, password)
-            self.assertEqual(client.default_prefix, default_prefix)
-            self.assertEqual(client.sessionkey, sessionkey)
-            self.assertEqual(client.capath, capath)
-            self.assertEqual(client.cafile, cafile)
-            self.assertEqual(client.timeout, timeout)
-            self.assertEqual(client.max_retry, max_retry)
+            self.assertEqual(client.base_url, self.base_url)
+            self.assertEqual(client.username, self.username)
+            self.assertEqual(client.password, self.password)
+            self.assertEqual(client.default_prefix, self.default_prefix)
+            self.assertEqual(client.sessionkey, self.sessionkey)
+            self.assertEqual(client.capath, self.capath)
+            self.assertEqual(client.cafile, self.cafile)
+            self.assertEqual(client.timeout, self.timeout)
+            self.assertEqual(client.max_retry, self.max_retry)
+
+    def test_redfish_client_no_root_resp(self):
+        client = redfish_client(base_url=self.base_url, check_connectivity=False)
+        self.assertIsNone(getattr(client, "root_resp", None))
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This allows a user to create a client without _knowing_ the IP they are connecting to up front. It gives the user the ability to create and pass around a client object as needed. Additionally, the default behavior is preserved.

* Added `check_connectivity` keyword arg to `RestClientBase`.
* Added `check_connectivity` keyword arg to `HTTPClient`.
* Added `check_connectivity` keyword arg to `redfish_client` function.
* Conditionally execute `get_root_object` during client instantiation based on the value of `check_connectivity`.
* Catch the resultant `AttributeError` in the case that `self.root` was not set due to `check_connectivity` being set to `False`.
* Small test refactor, added `setUp` method to `TestRedFishClient` class to make commonly used attributes members of the test case.
* Added new test for this functionality.
* Ensure that the `root` data/response added as attributes by the
`get_root_object` method are cached when `login` is called.
* Added new test to cover this case.

Test results:
```shell
python tests/rest/test_v1.py
...
----------------------------------------------------------------------
Ran 3 tests in 11.384s

OK
```
#163 