### PR TITLE
Added workaround for services incorrectly responding with 401 when accessing the service root

### DIFF
--- a/src/redfish/rest/v1.py
+++ b/src/redfish/rest/v1.py
@@ -596,6 +596,13 @@ class RestClientBase(object):
         except Exception as excp:
             raise excp
 
+        if resp.status == 401 and self.__authorization_key is None and self.__session_key is None:
+            # Workaround where the service incorrectly rejects access to service
+            # root when no credentials are provided
+            warnings.warn("Service incorrectly responded with HTTP 401 Unauthorized for the service root.  Contact your vendor.")
+            self.root = {}
+            self.root_resp = resp
+            return
         if resp.status != 200:
             raise ServerDownOrUnreachableError("Server not reachable, " \
                                                "return code: %d" % resp.status,response=resp)


### PR DESCRIPTION
Fix #165 

@v-ajitpanda FYI you may want to test this on your end before we merge this. I've stood up a system that returns 401 and it works well on my end.