### PR TITLE
Clarified the exception message raised when unable to access the service root

### DIFF
--- a/src/redfish/rest/v1.py
+++ b/src/redfish/rest/v1.py
@@ -611,8 +611,11 @@ class RestClientBase(object):
             self.root = {}
             self.root_resp = resp
             return
+        if resp.status == 503:
+            raise ServerDownOrUnreachableError("Service is busy, " \
+                                               "return code: %d" % resp.status,response=resp)
         if resp.status != 200:
-            raise ServerDownOrUnreachableError("Server not reachable, " \
+            raise ServerDownOrUnreachableError("Service not able to provide the service root, " \
                                                "return code: %d" % resp.status,response=resp)
 
         content = resp.text


### PR DESCRIPTION
I had some folks who were looking at the existing message in the "ServerDownOrUnreachableError" exception and were interpreting it as a network issue when in fact it's just a bad response from the service. Made adjustments to indicate the service is responsive (but just not in a satisfactory way).