### PR TITLE
Added workaround and warnings for session login when the service incorrectly does not provide the session location in the 'Location' response header

### DIFF
--- a/src/redfish/rest/v1.py
+++ b/src/redfish/rest/v1.py
@@ -290,6 +290,10 @@ class RestResponse(object):
             return self._session_location
 
         self._session_location = self.getheader('location')
+        if self._session_location is None:
+            warnings.warn("Service incorrectly did not provide the 'Location' response header when creating a session; attempting to "
+                          "get the session location from the response body.  Contact your vendor.")
+            self._session_location = self.dict["@odata.id"]
         return self._session_location
 
     @property


### PR DESCRIPTION
Fix #172 

After discussing this with others in the forum, we think it's beneficial to automate a workaround (and print warnings about the non-conformance). The Redfish-Protocol-Validator already flags this as an error, so vendors can test for it today.