### PR TITLE
Fixed bug in recent workaround logic for services not returning the 'Location' header

### DIFF
--- a/src/redfish/rest/v1.py
+++ b/src/redfish/rest/v1.py
@@ -288,6 +288,8 @@ class RestResponse(object):
         """Property for accessing the saved session location"""
         if self._session_location:
             return self._session_location
+        if self.status not in [200, 201, 202, 204]:
+            return None
 
         self._session_location = self.getheader('location')
         if self._session_location is None:


### PR DESCRIPTION
Fixed bug in recent workaround logic for services not returning the 'Location' header to not print the workaround warning for failed login attempts

Failed login attempts are expected to not return a Location header.