### PR TITLE
Fix propagating headers across different class instances

### DIFF
--- a/src/redfish/rest/v1.py
+++ b/src/redfish/rest/v1.py
@@ -986,7 +986,7 @@ class RestClientBase(object):
         else:
             raise RetriesExhaustedError() from cause_exception
 
-    def login(self, username=None, password=None, auth=AuthMethod.SESSION, headers={}):
+    def login(self, username=None, password=None, auth=AuthMethod.SESSION, headers=None):
         """Login and start a REST session.  Remember to call logout() when"""
         """ you are done.
 
@@ -1005,6 +1005,8 @@ class RestClientBase(object):
 
         self.__username = username if username else self.__username
         self.__password = password if password else self.__password
+
+        headers = headers if headers else {}
 
         if auth == AuthMethod.BASIC:
             auth_key = base64.b64encode(('%s:%s' % (self.__username,


### PR DESCRIPTION
There was a bug in login function of RestClientBase which incorrectly propagated headers across all instances of the class. Fix it.

The empty dictionary was created only once in the parameter list, and then reused for all following instances.

The bug appears e.g. when trying to change the authorization method in the same service using redfish library:
  1) creating redfish_client with basic authorization adds a header
     to a global headers dictionary ('Authorization')
  2) creating a totally separate instance of redfish_client with
     session fails, because we get unexpected 'Authorization'
     header which was created in previous instance and propagated
     incorrectly

Simplified example to explain the incorrect use of dictionary parameter:
```
class Example:
    def bad_param(self, optional_dict={}):
        if not optional_dict:
            print('Optional dict is empty, adding something')
            optional_dict['some'] = 'thing'
        else:
            print(f'Optional dict is NOT empty: {optional_dict}')

example1 = Example()
example1.bad_param()
example2 = Example()
example2.bad_param()
```