### PR TITLE
Add urllib3 zstd extra to requirements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,10 @@ cache:
 - pip
 python:
 - '3.8'
-- '3.9'
 - '3.11'
+- '3.12'
+- '3.13'
+- '3.14'
 before_install:
 - pip install -U pip
 - pip install -U setuptools

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,4 @@ jsonpointer
 requests
 requests-toolbelt
 requests-unixsocket
-urllib3[zstd]>=2.6.0
+urllib3[zstd]>=2.6.0 ; python_version >= '3.9'

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ jsonpointer
 requests
 requests-toolbelt
 requests-unixsocket
+urllib3[zstd]>=2.6.0

--- a/setup.py
+++ b/setup.py
@@ -41,5 +41,8 @@ setup(name='redfish',
           ],
           ':python_version >= "3.5"': [
               'jsonpatch'
+          ],
+          ':python_version >= "3.9"': [
+              'urllib3[zstd]>=2.6.0'
           ]
       })

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py38,py39,py311
+envlist = py38,py311,py312,py313,py314
 
 [testenv]
 usedevelop = True
@@ -18,4 +18,4 @@ deps = flake8
 commands = flake8 tests/ src/redfish/discovery
 
 [travis]
-python = 3.11: py311
+python = 3.14: py314


### PR DESCRIPTION
- `requests` send "Accept-Encoding: *", which some services answer with `Content-Encoding: zstd`. Without a zstd-capable `urllib3`, the response body is returned raw and fails JSON parsing ("Service responded with invalid JSON").
- `>=2.6.0` is the first release where the [zstd] extra installs the stdlib-based decoder (`backports.zstd` on Python ≤3.13, `compression.zstd` on 3.14+) instead of the legacy zstandard package, giving reliable `Content-Encoding: zstd` decompression across Python versions.